### PR TITLE
Check whether existing weights are loaded

### DIFF
--- a/src/mlpack/methods/reinforcement_learning/q_learning_impl.hpp
+++ b/src/mlpack/methods/reinforcement_learning/q_learning_impl.hpp
@@ -52,7 +52,9 @@ QLearning<
   targetNetwork = learningNetwork;
 
   // Set up q-learning network.
-  learningNetwork.ResetParameters();
+  if(leaningNetwork.Parameters().is_empty())
+    learningNetwork.ResetParameters();
+      
   targetNetwork.ResetParameters();
 
   #if ENS_VERSION_MAJOR == 1


### PR DESCRIPTION
If no weights are loaded, the network is empty and new weights are generated. 
If not, the already loaded weights will be used.